### PR TITLE
#3398: Fix for FIPS enabled in bookshelf using bookshelf s3 url with …

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
@@ -210,8 +210,9 @@
         %%
         %% This is the reason that the only supported configuration for the fips
         %% package is standalone. We will allow http over localhost so that the
-        %% chef server can talk to bookshelf.
-        {s3_url, "http://<%= node['private_chef']['bookshelf']['listen'] %>:<%= node['private_chef']['bookshelf']['port'] %>"},
+        %% chef server can talk to bookshelf. We can give provide bookshelf['url'] = 'http://127.0.0.1:4321' for naking it work for FIPS enabled
+       %% {s3_url, "http://<%= node['private_chef']['bookshelf']['listen'] %>:<%= node['private_chef']['bookshelf']['port'] %>"},
+         {s3_url, "<%= @helper.bookshelf_s3_url %>"},
         <% else -%>
         {s3_url, "<%= @helper.bookshelf_s3_url %>"},
         <% end %>


### PR DESCRIPTION
…localhost setting in chef-server.rb

### Description

Updated oc_erchef.config.erb with s3 url location for FIPS enabled .
        <% if node['private_chef']['fips_enabled'] -%>
        %% When we're using a fips openssl, we default to using http for bookshelf.
        %% The reason for this is because we do not have a TLS implementation for
        %% Erlang when we turn on fips.
        %%
        %% This is the reason that the only supported configuration for the fips
        %% package is standalone. We will allow http over localhost so that the
        %% chef server can talk to bookshelf. We can give provide bookshelf['url'] = 'http://127.0.0.1:4321' for naking it work for FIPS enabled
       %% {s3_url, "http://<%= node['private_chef']['bookshelf']['listen'] %>:<%= node['private_chef']['bookshelf']['port'] %>"},
         {s3_url, "<%= @helper.bookshelf_s3_url %>"},
        <% else -%>
        {s3_url, "<%= @helper.bookshelf_s3_url %>"},
        <% end %>
### Issues Resolved
#3398 issu has been resolved with this fix for FIPS 
[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
